### PR TITLE
Gate excess computation

### DIFF
--- a/src/core/MPCStats.cpp
+++ b/src/core/MPCStats.cpp
@@ -105,13 +105,11 @@ CMPCStats::CMPCStats(const char* fnStats, int anPrunes) {
     					nDataPoints++;
     				}
     			}
-    			if (nDataPoints>1) {
+    			if (nDataPoints>20) {
     				c=xy/xx;
     				sigma=sqrt((yy-xy*xy/xx)/(nDataPoints-1));
-    				if (nDataPoints>20) {
-    					sds[0][height][nEmpty][nCut]=float(sigma);
-    					crs[height][nEmpty][nCut]=float(1/c);
-    				}
+    				sds[0][height][nEmpty][nCut]=float(sigma);
+    				crs[height][nEmpty][nCut]=float(1/c);
     			}
     		}
     	}

--- a/src/core/MPCStats.cpp
+++ b/src/core/MPCStats.cpp
@@ -25,7 +25,8 @@ CMPCStats::CMPCStats(const char* fnStats, int anPrunes) {
     char separator;
     int nRead, nRows, dummy, row, col, height, nCut, nDataPoints = 0, iPrune, iVersion;
     int iStartCol;
-    double xx = 0.0, xy = 0.0, yy = 0.0, c, sigma;
+    double xx = 0.0, xy = 0.0, yy = 0.0;
+    float c = 0.0, sigma = 0.0;
 
     // open stats file
     fpStats=fopen(fnStats,"r");
@@ -106,10 +107,9 @@ CMPCStats::CMPCStats(const char* fnStats, int anPrunes) {
     				}
     			}
     			if (nDataPoints>20) {
-    				c=xy/xx;
     				sigma=sqrt((yy-xy*xy/xx)/(nDataPoints-1));
-    				sds[0][height][nEmpty][nCut]=float(sigma);
-    				crs[height][nEmpty][nCut]=float(1/c);
+    				sds[0][height][nEmpty][nCut]=sigma;
+    				crs[height][nEmpty][nCut]=xx/xy;
     			}
     		}
     	}
@@ -125,8 +125,8 @@ CMPCStats::CMPCStats(const char* fnStats, int anPrunes) {
     				c=crs[height][nEmpty][nCut];
     			}
     			else {
-    				sds[0][height][nEmpty][nCut]=float(sigma);
-    				crs[height][nEmpty][nCut]=float(c);
+    				sds[0][height][nEmpty][nCut]=sigma;
+    				crs[height][nEmpty][nCut]=c;
     			}
     		}
     	}


### PR DESCRIPTION
I saw ntest was doing floating point square roots and got curious so I looked at the code and saw some optimization opportunities in the scoring module.

* The `c` and `sigma` variables are not used outside of the inner conditional so we can move them inside, and get rid of the outer conditional. Depending on the workload input this will sometimes save 1 FP square-root, 2 FP divides, 1 FP multiply, and 2 FP subtracts.
* And then, `c` and `sigma` are stored into `TCutData` which is typedef'd to `float` and that is why they are down converted before storing. So there is no need for double precision math in the first place! We can set both of those to `float` and lose the conversion. This saves conversion instructions plus the fdiv's will be faster. Also `c` is not used so just compute `1/c` which saves another divide.