### PR TITLE
Fix GCC warning and UBSan error

### DIFF
--- a/src/core/Cache.cpp
+++ b/src/core/Cache.cpp
@@ -212,7 +212,7 @@ void CCacheData::Print(bool blackMove, u1 count) const {
 CCache::CCache(u4 anbuckets) {
     fprintf(stderr, "Creating cache with %d buckets (%llu MB)\n",anbuckets, static_cast<unsigned long long>(anbuckets*sizeof(CCacheData)>>20));
     nBuckets=anbuckets;
-    buckets=reinterpret_cast<CCacheData*>(calloc(sizeof(CCacheData), nBuckets));
+    buckets=reinterpret_cast<CCacheData*>(calloc(nBuckets, sizeof(CCacheData)));
     assert(buckets);
     assert((nBuckets&(nBuckets-1))==0);
 

--- a/src/n64/solve.cpp
+++ b/src/n64/solve.cpp
@@ -277,7 +277,7 @@ inline int orderMoves(int moveScores[], int alpha, int beta, u64 mover, u64 enem
 		if (bitSet(sq, moverMobility)) {
 			const int index = int(empty - search->emptyArray);
 
-			int score = -enemyPostMoveMobilityCount(sq, mover, enemy)<<8;
+			int score = -(enemyPostMoveMobilityCount(sq, mover, enemy)<<8);
 			score+=hashCutsOff(alpha, beta, mover, enemy, search)<<15;
 			score+= bit(sq, corners)<<7;
 			score += bit(sq, parity)<<5;


### PR DESCRIPTION
Trivial fixes to a GCC Warning regarding calloc arguments and an Undefined Behavior Sanitizer Error about shifting negative values.

These were discovered as part of the SPEC CPUv8 Benchmark development.