### PR TITLE
Fix macOS build issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.5)
 
 project(ntest)
 
@@ -53,6 +53,11 @@ target_link_libraries(allpos mainlib core game patterns odk n64)
 add_test(ntest_basic ntest o)
 
 if(${UNIX})
-    EXEC_PROGRAM(ln ARGS -sf "../src/resource/*"
-                 "${CMAKE_BINARY_DIR}")
+    # Copy resource files to build directory
+    file(COPY "${CMAKE_SOURCE_DIR}/resource/solver12.txt" DESTINATION "${CMAKE_BINARY_DIR}/resource")
+    file(COPY "${CMAKE_SOURCE_DIR}/resource/resource/" DESTINATION "${CMAKE_BINARY_DIR}/resource")
+    file(COPY "${CMAKE_SOURCE_DIR}/TestGames.ggf" DESTINATION "${CMAKE_BINARY_DIR}")
+    file(COPY "${CMAKE_SOURCE_DIR}/parameters.txt" DESTINATION "${CMAKE_BINARY_DIR}")
+    file(COPY "${CMAKE_SOURCE_DIR}/coefficients/" DESTINATION "${CMAKE_BINARY_DIR}/coefficients")
+    file(COPY "${CMAKE_SOURCE_DIR}/../resource/coefficients/" DESTINATION "${CMAKE_BINARY_DIR}/coefficients")
 endif()

--- a/src/Evaluator.cpp
+++ b/src/Evaluator.cpp
@@ -23,7 +23,7 @@ using namespace std;
 #define INLINE_HINT
 typedef unsigned long TConfig;
 #elif __GNUC__ >= 4
-#define INLINE_HINT inline __attribute__((always_inline)) 
+#define INLINE_HINT inline __attribute__((always_inline))
 typedef unsigned long TConfig;
 #elif defined(WIN32)
 #define INLINE_HINT __forceinline
@@ -33,51 +33,50 @@ typedef uint64_t TConfig;
 typedef unsigned long TConfig;
 #endif
 
-class CEvaluatorList: public std::map<CEvaluatorInfo, CEvaluator*> {
+class CEvaluatorList : public std::map<CEvaluatorInfo, CEvaluator *> {
 public:
-    ~CEvaluatorList();
+  ~CEvaluatorList();
 };
 
 static CEvaluatorList evaluatorList;
 
 CEvaluatorList::~CEvaluatorList() {
-    for (iterator it=begin(); it!=end(); it++) {
-        delete it->second;
-    }
+  for (iterator it = begin(); it != end(); it++) {
+    delete it->second;
+  }
 }
 
-CEvaluator* CEvaluator::FindEvaluator(char evaluatorType, char coeffSet) {
-    CEvaluatorInfo evaluatorInfo;
-    CEvaluator* result = nullptr;
-    map<CEvaluatorInfo, CEvaluator*>::iterator ptr;
+CEvaluator *CEvaluator::FindEvaluator(char evaluatorType, char coeffSet) {
+  CEvaluatorInfo evaluatorInfo;
+  CEvaluator *result = nullptr;
+  map<CEvaluatorInfo, CEvaluator *>::iterator ptr;
 
-    evaluatorInfo.evaluatorType=evaluatorType;
-    evaluatorInfo.coeffSet=coeffSet;
+  evaluatorInfo.evaluatorType = evaluatorType;
+  evaluatorInfo.coeffSet = coeffSet;
 
-    ptr=evaluatorList.find(evaluatorInfo);
-    if (ptr==evaluatorList.end()) {
-        switch(evaluatorType) {
-        case 'J': {
-            int nFiles= (coeffSet>='9')?10:6;
-            result=new CEvaluator(FNBase(evaluatorType, coeffSet), nFiles);
-            break;
-                  }
-        default:
-            assert(0);
-        }
-        assert(result);
-        evaluatorList[evaluatorInfo]=result;
+  ptr = evaluatorList.find(evaluatorInfo);
+  if (ptr == evaluatorList.end()) {
+    switch (evaluatorType) {
+    case 'J': {
+      int nFiles = (coeffSet >= '9') ? 10 : 6;
+      result = new CEvaluator(FNBase(evaluatorType, coeffSet), nFiles);
+      break;
     }
-    else {
-        result=(*ptr).second;
+    default:
+      assert(0);
     }
-    return result;
+    assert(result);
+    evaluatorList[evaluatorInfo] = result;
+  } else {
+    result = (*ptr).second;
+  }
+  return result;
 }
 
 std::string CEvaluator::FNBase(char evaluatorType, char coeffSet) {
-    std::ostringstream os;
-    os << "coefficients/" << evaluatorType << coeffSet;
-    return os.str();
+  std::ostringstream os;
+  os << "coefficients/" << evaluatorType << coeffSet;
+  return os.str();
 }
 
 //////////////////////////////////////////////////////
@@ -89,206 +88,220 @@ std::string CEvaluator::FNBase(char evaluatorType, char coeffSet) {
 //!
 //! read in the file (float format) and write it out in i2 format.
 //! reopen the file and read the iversion and fParams flags
-static void ConvertFile(FILE*& fp, std::string fn, int& iVersion, u4& fParams) {
-    // convert float coefficient file to int. Write new coefficients file to disk and reload.
-    std::vector<i2> newCoeffs;
-    float oldCoeff;
-    while (fread(&oldCoeff, sizeof(oldCoeff), 1, fp)) {
-        int coeff=int(oldCoeff*kStoneValue);
-        if (coeff>0x3FFF)
-            coeff=0x3FFF;
-        if (coeff<-0x3FFF)
-            coeff=-0x3FFF;
-        newCoeffs.push_back(i2(coeff));
-    }
-    fclose(fp);
-    fp=fopen(fn.c_str(), "wb");
-    if (!fp)
-        throw std::string("Can't open coefficient file for conversion: ")+fn;
-    fParams=100;
-    fwrite(&iVersion, sizeof(int), 1, fp);
-    fwrite(&fParams, sizeof(int), 1, fp);
-    fwrite(&newCoeffs[0], sizeof(u2), newCoeffs.size(), fp);
-    fclose(fp);
-    fp=fopen(fn.c_str(), "rb");
-    if (!fp)
-        throw std::string("Can't open coefficient file ")+fn;
-    size_t result=fread(&iVersion, sizeof(int), 1, fp);
-    assert(result==1);
-    result=fread(&fParams, sizeof(int), 1, fp);
-    assert(result==1);
+static void ConvertFile(FILE *&fp, std::string fn, int &iVersion, u4 &fParams) {
+  // convert float coefficient file to int. Write new coefficients file to disk
+  // and reload.
+  std::vector<i2> newCoeffs;
+  float oldCoeff;
+  while (fread(&oldCoeff, sizeof(oldCoeff), 1, fp)) {
+    int coeff = int(oldCoeff * kStoneValue);
+    if (coeff > 0x3FFF)
+      coeff = 0x3FFF;
+    if (coeff < -0x3FFF)
+      coeff = -0x3FFF;
+    newCoeffs.push_back(i2(coeff));
+  }
+  fclose(fp);
+  fp = fopen(fn.c_str(), "wb");
+  if (!fp)
+    throw std::string("Can't open coefficient file for conversion: ") + fn;
+  fParams = 100;
+  fwrite(&iVersion, sizeof(int), 1, fp);
+  fwrite(&fParams, sizeof(int), 1, fp);
+  fwrite(&newCoeffs[0], sizeof(u2), newCoeffs.size(), fp);
+  fclose(fp);
+  fp = fopen(fn.c_str(), "rb");
+  if (!fp)
+    throw std::string("Can't open coefficient file ") + fn;
+  size_t result = fread(&iVersion, sizeof(int), 1, fp);
+  assert(result == 1);
+  result = fread(&fParams, sizeof(int), 1, fp);
+  assert(result == 1);
 }
 
 //! Read in Evaluator coefficients from a coefficient file
 //!
-//! If the file's fParams is 14, coefficients are stored as floats and are in units of stones
-//! If the file's fParams is 100, coefficients are stored as u2s and are in units of centistones.
+//! If the file's fParams is 14, coefficients are stored as floats and are in
+//! units of stones If the file's fParams is 100, coefficients are stored as u2s
+//! and are in units of centistones.
 //!
 //! \throw string if error
-CEvaluator::CEvaluator(const std::string& fnBase, int nFiles) {
-    int map,  iFile, coeffStart, packedCoeff;
-    int nIDs, nConfigs, id, config, cid;
-    uint32_t configpm1, configpm2, mapsize;
-    bool fHasPotMobs;
-    float* rawCoeffs=0;    //!< for use with raw (float) coeffs
-    i2* i2Coeffs=0;        //!< for use with converted (packed) coeffs
-    TCoeff coeff;
-    int iSubset, nSubsets, nEmpty;
+CEvaluator::CEvaluator(const std::string &fnBase, int nFiles) {
+  int map, iFile, coeffStart, packedCoeff;
+  int nIDs, nConfigs, id, config, cid;
+  uint32_t configpm1, configpm2, mapsize;
+  bool fHasPotMobs;
+  float *rawCoeffs = 0; //!< for use with raw (float) coeffs
+  i2 *i2Coeffs = 0;     //!< for use with converted (packed) coeffs
+  TCoeff coeff;
+  int iSubset, nSubsets, nEmpty;
 
-    // some parameters are set based on the Evaluator version number
-    int nSetWidth=60/nFiles;
-    char cCoeffSet=fnBase.end()[-1];
+  // some parameters are set based on the Evaluator version number
+  int nSetWidth = 60 / nFiles;
+  char cCoeffSet = fnBase.end()[-1];
 
+  // read in sets
+  nSets = 0;
+  for (iFile = 0; iFile < nFiles; iFile++) {
+    FILE *fp;
+    std::string fn;
+    int iVersion;
 
-    // read in sets
-    nSets=0;
-    for (iFile=0; iFile<nFiles; iFile++) {
-        FILE* fp;
-        std::string fn;
-        int iVersion;
+    // get file name
+    std::ostringstream os;
+    os << fnBase << char('a' + (iFile % nFiles)) << ".cof";
+    fn = os.str();
 
-        // get file name
-        std::ostringstream os;
-        os << fnBase << char('a'+(iFile%nFiles)) << ".cof";
-        fn=os.str();
+    // open file
+    fp = fopen(fn.c_str(), "rb");
+    if (!fp)
+      throw std::string("Can't open coefficient file ") + fn;
 
-        // open file
-        fp=fopen(fn.c_str(),"rb");
-        if (!fp)
-            throw std::string("Can't open coefficient file ")+fn;
-
-        // read in version and parameter info
-        u4 fParams;
-        assert(fread(&iVersion, sizeof(iVersion), 1, fp) == 1);
-        assert(fread(&fParams, sizeof(fParams), 1, fp) == 1);
-        if (iVersion==1 && fParams==14) {
-            ConvertFile(fp, fn, iVersion, fParams);
-        }
-        if (iVersion!=1 || (fParams!=100)) {
-            throw std::string("error reading from coefficients file ")+fnBase;
-        }
-
-        // calculate the number of subsets
-        nSubsets=2;
-
-        for (iSubset=0; iSubset<nSubsets; iSubset++) {
-            // allocate memory for the black and white versions of the coefficients
-            coeffs[nSets]=new TCoeff[nCoeffsJ];
-            CHECKNEW(coeffs[nSets] != NULL);
-
-            // put the coefficients in the proper place
-            for (map=0; map<nMapsJ; map++) {
-
-                // inital calculations
-                nIDs=mapsJ[map].NIDs();
-                nConfigs=mapsJ[map].NConfigs();
-                mapsize=mapsJ[map].size;
-                coeffStart=coeffStartsJ[map];
-
-                // get raw coefficients from file
-                i2Coeffs=new i2[nIDs];
-                CHECKNEW(i2Coeffs!=NULL);
-                if (fread(i2Coeffs,sizeof(u2),nIDs,fp)<size_t(nIDs))
-                    throw std::string("error reading from coefficients file")+fnBase;
-
-                // convert raw coefficients[id] to i2s[config]
-                for (config=0; config<nConfigs; config++) {
-                    id=mapsJ[map].ConfigToID(config);
-
-                    coeff = i2Coeffs[id];
-
-                    cid=config+coeffStart;
-
-                    if (map==PARJ) {
-                        // odd-even correction, only in Parity coefficient.
-                        if (cCoeffSet>='A') {
-                            if (iFile>=7)
-                                coeff+=TCoeff(kStoneValue*.65);
-                            else if (iFile==6)
-                                coeff+=TCoeff(kStoneValue*.33);
-                        }
-                    }
-                    
-                    // coeff value has first 2 bytes=coeff, 3rd byte=potmob1, 4th byte=potmob2
-                    if (map<M1J) {    // pattern maps
-                        // restrict the coefficient to 2 bytes
-                        if (coeff>0x3FFF)
-                            packedCoeff=0x3FFF;
-                        if (coeff<-0x3FFF)
-                            packedCoeff=-0x3FFF;
-                        else
-                            packedCoeff=coeff;
-                        
-                        // get linear pot mob info
-                        if (map<=D5J) {    // straight-line maps
-                            fHasPotMobs=true;
-                            configpm1=configToPotMob[0][mapsize][config];
-                            configpm2=configToPotMob[1][mapsize][config];
-                        }
-                        
-                        else if (map==C4J) {    // corner triangle maps
-                            fHasPotMobs=true;
-                            configpm1=configToPotMobTriangle[0][config];
-                            configpm2=configToPotMobTriangle[1][config];
-                        }
-
-                        else {    // 2x4, 2x5, edge+2X
-                            fHasPotMobs=false;
-                        }
-
-                        // pack coefficient and pot mob together
-                        if (fHasPotMobs)
-                            packedCoeff=(packedCoeff<<16) | (configpm1<<8) | (configpm2);                        
-
-                        coeffs[nSets][cid]=packedCoeff;
-                    }
-                    
-                    else {        // non-pattern maps
-                        coeffs[nSets][cid]=coeff;
-                    }
-                }
-
-                delete[] rawCoeffs;
-                delete[] i2Coeffs;
-            }
-
-            // fold 2x4 corners into 2x5 corners
-            TCoeff* pcf2x4, *pcf2x5;
-            TConfig c2x4;
-
-            pcf2x4=&(coeffs[nSets][coeffStartsJ[C2x4J]]);
-            pcf2x5=&(coeffs[nSets][coeffStartsJ[C2x5J]]);
-            // fold coefficients in
-            for (config=0; config<9*6561; config++) {
-                c2x4=configs2x5To2x4[config];
-                pcf2x5[config]+=pcf2x4[c2x4];
-            }
-            // zero out 2x4 coefficients
-            for (config=0;config<6561; config++) {
-                pcf2x4[config]=0;
-            }
-
-            // Set the pcoeffs array and the fParameters
-            for (nEmpty=59-nSetWidth*iFile; nEmpty>=50-nSetWidth*iFile; nEmpty--) {
-                // if this is a set of the wrong parity, do nothing
-                if ((nEmpty&1)==iSubset)
-                    continue;
-                pcoeffs[nEmpty]=coeffs[nSets];
-            }
-
-            nSets++;
-        }
-        fclose(fp);
+    // read in version and parameter info
+    u4 fParams = 0;
+    iVersion = 0;
+    size_t versionRead = fread(&iVersion, sizeof(iVersion), 1, fp);
+    size_t paramsRead = fread(&fParams, sizeof(fParams), 1, fp);
+    if (versionRead != 1 || paramsRead != 1) {
+      std::ostringstream err;
+      err << "error reading header from coefficients file " << fn << " (read "
+          << versionRead << " version, " << paramsRead << " params)";
+      throw std::string(err.str());
     }
+    if (iVersion == 1 && fParams == 14) {
+      ConvertFile(fp, fn, iVersion, fParams);
+    }
+    if (iVersion != 1 || (fParams != 100)) {
+      std::ostringstream err;
+      err << "error reading from coefficients file " << fn
+          << " (version=" << iVersion << ", fParams=" << fParams << ")";
+      throw std::string(err.str());
+    }
+
+    // calculate the number of subsets
+    nSubsets = 2;
+
+    for (iSubset = 0; iSubset < nSubsets; iSubset++) {
+      // allocate memory for the black and white versions of the coefficients
+      coeffs[nSets] = new TCoeff[nCoeffsJ];
+      CHECKNEW(coeffs[nSets] != NULL);
+
+      // put the coefficients in the proper place
+      for (map = 0; map < nMapsJ; map++) {
+
+        // inital calculations
+        nIDs = mapsJ[map].NIDs();
+        nConfigs = mapsJ[map].NConfigs();
+        mapsize = mapsJ[map].size;
+        coeffStart = coeffStartsJ[map];
+
+        // get raw coefficients from file
+        i2Coeffs = new i2[nIDs];
+        CHECKNEW(i2Coeffs != NULL);
+        if (fread(i2Coeffs, sizeof(u2), nIDs, fp) < size_t(nIDs))
+          throw std::string("error reading from coefficients file") + fnBase;
+
+        // convert raw coefficients[id] to i2s[config]
+        for (config = 0; config < nConfigs; config++) {
+          id = mapsJ[map].ConfigToID(config);
+
+          coeff = i2Coeffs[id];
+
+          cid = config + coeffStart;
+
+          if (map == PARJ) {
+            // odd-even correction, only in Parity coefficient.
+            if (cCoeffSet >= 'A') {
+              if (iFile >= 7)
+                coeff += TCoeff(kStoneValue * .65);
+              else if (iFile == 6)
+                coeff += TCoeff(kStoneValue * .33);
+            }
+          }
+
+          // coeff value has first 2 bytes=coeff, 3rd byte=potmob1, 4th
+          // byte=potmob2
+          if (map < M1J) { // pattern maps
+            // restrict the coefficient to 2 bytes
+            if (coeff > 0x3FFF)
+              packedCoeff = 0x3FFF;
+            if (coeff < -0x3FFF)
+              packedCoeff = -0x3FFF;
+            else
+              packedCoeff = coeff;
+
+            // get linear pot mob info
+            if (map <= D5J) { // straight-line maps
+              fHasPotMobs = true;
+              configpm1 = configToPotMob[0][mapsize][config];
+              configpm2 = configToPotMob[1][mapsize][config];
+            }
+
+            else if (map == C4J) { // corner triangle maps
+              fHasPotMobs = true;
+              configpm1 = configToPotMobTriangle[0][config];
+              configpm2 = configToPotMobTriangle[1][config];
+            }
+
+            else { // 2x4, 2x5, edge+2X
+              fHasPotMobs = false;
+            }
+
+            // pack coefficient and pot mob together
+            if (fHasPotMobs)
+              packedCoeff =
+                  (packedCoeff << 16) | (configpm1 << 8) | (configpm2);
+
+            coeffs[nSets][cid] = packedCoeff;
+          }
+
+          else { // non-pattern maps
+            coeffs[nSets][cid] = coeff;
+          }
+        }
+
+        delete[] rawCoeffs;
+        delete[] i2Coeffs;
+      }
+
+      // fold 2x4 corners into 2x5 corners
+      TCoeff *pcf2x4, *pcf2x5;
+      TConfig c2x4;
+
+      pcf2x4 = &(coeffs[nSets][coeffStartsJ[C2x4J]]);
+      pcf2x5 = &(coeffs[nSets][coeffStartsJ[C2x5J]]);
+      // fold coefficients in
+      for (config = 0; config < 9 * 6561; config++) {
+        c2x4 = configs2x5To2x4[config];
+        pcf2x5[config] += pcf2x4[c2x4];
+      }
+      // zero out 2x4 coefficients
+      for (config = 0; config < 6561; config++) {
+        pcf2x4[config] = 0;
+      }
+
+      // Set the pcoeffs array and the fParameters
+      for (nEmpty = 59 - nSetWidth * iFile; nEmpty >= 50 - nSetWidth * iFile;
+           nEmpty--) {
+        // if this is a set of the wrong parity, do nothing
+        if ((nEmpty & 1) == iSubset)
+          continue;
+        pcoeffs[nEmpty] = coeffs[nSets];
+      }
+
+      nSets++;
+    }
+    fclose(fp);
+  }
 }
 
 CEvaluator::~CEvaluator() {
-    int set;
+  int set;
 
-    // delete the coeffs array
-    for (set=0; set<nSets; set++) {
-        delete[] coeffs[set];
-    }
+  // delete the coeffs array
+  for (set = 0; set < nSets; set++) {
+    delete[] coeffs[set];
+  }
 }
 
 ////////////////////////////////////////
@@ -300,385 +313,426 @@ CEvaluator::~CEvaluator() {
 //    1 - final value
 //    2 - board, final value and all components
 // only works with OLD_EVAL set to 1 (slower old version)
-const int iDebugEval=0;
+const int iDebugEval = 0;
 
-INLINE_HINT TCoeff ConfigValue(const TCoeff* pcmove, TConfig config, int map, int offset) {
-    TCoeff value=pcmove[config+offset];
-    if (iDebugEval>1)
-        printf("Config: %5lu, Id: %5hu, Value: %4d\n", config, mapsJ[map].ConfigToID(u2(config)), value);
-    return value;
+INLINE_HINT TCoeff ConfigValue(const TCoeff *pcmove, TConfig config, int map,
+                               int offset) {
+  TCoeff value = pcmove[config + offset];
+  if (iDebugEval > 1)
+    printf("Config: %5lu, Id: %5hu, Value: %4d\n", config,
+           mapsJ[map].ConfigToID(u2(config)), value);
+  return value;
 }
 
-INLINE_HINT TCoeff PatternValue(TConfig configs[], const TCoeff* pcmove, int pattern, int map, int offset) {
-    TConfig config=configs[pattern];
-    TCoeff value=pcmove[config+offset];
-    if (iDebugEval>1)
-        printf("Pattern: %2d - Config: %5lu, Id: %5hu, Value: %4d (pms %2d, %2d)\n",
-                pattern, config, mapsJ[map].ConfigToID(u2(config)), value>>16, (value>>8)&0xFF, value&0xFF);
-    return value;
+INLINE_HINT TCoeff PatternValue(TConfig configs[], const TCoeff *pcmove,
+                                int pattern, int map, int offset) {
+  TConfig config = configs[pattern];
+  TCoeff value = pcmove[config + offset];
+  if (iDebugEval > 1)
+    printf("Pattern: %2d - Config: %5lu, Id: %5hu, Value: %4d (pms %2d, %2d)\n",
+           pattern, config, mapsJ[map].ConfigToID(u2(config)), value >> 16,
+           (value >> 8) & 0xFF, value & 0xFF);
+  return value;
 }
 
-INLINE_HINT TCoeff ConfigPMValue(const TCoeff* pcmove, TConfig config, int map, int offset) {
-    TCoeff value=pcmove[config+offset];
-    if (iDebugEval>1)
-        printf("Config: %5lu, Id: %5hu, Value: %4d (pms %2d, %2d)\n",
-                config, mapsJ[map].ConfigToID(u2(config)), value>>16, (value>>8)&0xFF, value&0xFF);
-    return value;
+INLINE_HINT TCoeff ConfigPMValue(const TCoeff *pcmove, TConfig config, int map,
+                                 int offset) {
+  TCoeff value = pcmove[config + offset];
+  if (iDebugEval > 1)
+    printf("Config: %5lu, Id: %5hu, Value: %4d (pms %2d, %2d)\n", config,
+           mapsJ[map].ConfigToID(u2(config)), value >> 16, (value >> 8) & 0xFF,
+           value & 0xFF);
+  return value;
 }
-
 
 // offsetJs for coefficients
-constexpr int offsetJR1 = 0, sizeJR1 = 6561,
-offsetJR2 = offsetJR1 + sizeJR1, sizeJR2 = 6561,
-offsetJR3 = offsetJR2 + sizeJR2, sizeJR3 = 6561,
-offsetJR4 = offsetJR3 + sizeJR3, sizeJR4 = 6561,
-offsetJD8 = offsetJR4 + sizeJR4, sizeJD8 = 6561,
-offsetJD7 = offsetJD8 + sizeJD8, sizeJD7 = 2187,
-offsetJD6 = offsetJD7 + sizeJD7, sizeJD6 = 729,
-offsetJD5 = offsetJD6 + sizeJD6, sizeJD5 = 243,
-offsetJTriangle = offsetJD5 + sizeJD5, sizeJTriangle = 9 * 6561,
-offsetJC4 = offsetJTriangle + sizeJTriangle, sizeJC4 = 6561,
-offsetJC5 = offsetJC4 + sizeJC4, sizeJC5 = 6561 * 9,
-offsetJEX = offsetJC5 + sizeJC5, sizeJEX = 6561 * 9,
-offsetJMP = offsetJEX + sizeJEX, sizeJMP = 64,
-offsetJMO = offsetJMP + sizeJMP, sizeJMO = 64,
-offsetJPMP = offsetJMO + sizeJMO, sizeJPMP = 64,
-offsetJPMO = offsetJPMP + sizeJPMP, sizeJPMO = 64,
-offsetJPAR = offsetJPMO + sizeJPMO; // sizeJPAR = 2;
+constexpr int offsetJR1 = 0, sizeJR1 = 6561, offsetJR2 = offsetJR1 + sizeJR1,
+              sizeJR2 = 6561, offsetJR3 = offsetJR2 + sizeJR2, sizeJR3 = 6561,
+              offsetJR4 = offsetJR3 + sizeJR3, sizeJR4 = 6561,
+              offsetJD8 = offsetJR4 + sizeJR4, sizeJD8 = 6561,
+              offsetJD7 = offsetJD8 + sizeJD8, sizeJD7 = 2187,
+              offsetJD6 = offsetJD7 + sizeJD7, sizeJD6 = 729,
+              offsetJD5 = offsetJD6 + sizeJD6, sizeJD5 = 243,
+              offsetJTriangle = offsetJD5 + sizeJD5, sizeJTriangle = 9 * 6561,
+              offsetJC4 = offsetJTriangle + sizeJTriangle, sizeJC4 = 6561,
+              offsetJC5 = offsetJC4 + sizeJC4, sizeJC5 = 6561 * 9,
+              offsetJEX = offsetJC5 + sizeJC5, sizeJEX = 6561 * 9,
+              offsetJMP = offsetJEX + sizeJEX, sizeJMP = 64,
+              offsetJMO = offsetJMP + sizeJMP, sizeJMO = 64,
+              offsetJPMP = offsetJMO + sizeJMO, sizeJPMP = 64,
+              offsetJPMO = offsetJPMP + sizeJPMP, sizeJPMO = 64,
+              offsetJPAR = offsetJPMO + sizeJPMO; // sizeJPAR = 2;
 
 // value all the edge patterns. return the sum of the values.
-static INLINE_HINT TCoeff ValueEdgePatternsJ(const TCoeff* pcmove, TConfig config1, TConfig config2) {
-    u4 configs2x5;
-    TCoeff value;
+static INLINE_HINT TCoeff ValueEdgePatternsJ(const TCoeff *pcmove,
+                                             TConfig config1, TConfig config2) {
+  u4 configs2x5;
+  TCoeff value;
 
-    value=0;
-    configs2x5 = row1To2x5[config1] + row2To2x5[config2];
-    value+=ConfigValue(pcmove, configs2x5&0xFFFF, C2x5J, offsetJC5);
-    value+=ConfigValue(pcmove, configs2x5>>16,    C2x5J, offsetJC5);
-    value+=ConfigValue(pcmove, config1 * 3 +row2ToXX[config2],CR1XXJ, offsetJEX);
+  value = 0;
+  configs2x5 = row1To2x5[config1] + row2To2x5[config2];
+  value += ConfigValue(pcmove, configs2x5 & 0xFFFF, C2x5J, offsetJC5);
+  value += ConfigValue(pcmove, configs2x5 >> 16, C2x5J, offsetJC5);
+  value +=
+      ConfigValue(pcmove, config1 * 3 + row2ToXX[config2], CR1XXJ, offsetJEX);
 
-    // in J-configs, the values are multiplied by 65536
-    //assert((value&0xFFFF)==0);
-    return value;
+  // in J-configs, the values are multiplied by 65536
+  // assert((value&0xFFFF)==0);
+  return value;
 }
 
 // value all the triangle patterns. return the sum of the values.
-static INLINE_HINT TCoeff ValueTrianglePatternsJ(const TCoeff* pcmove, TConfig config1, TConfig config2, TConfig config3, TConfig config4) {
-    u4 configsTriangle;
-    TCoeff value;
+static INLINE_HINT TCoeff ValueTrianglePatternsJ(const TCoeff *pcmove,
+                                                 TConfig config1,
+                                                 TConfig config2,
+                                                 TConfig config3,
+                                                 TConfig config4) {
+  u4 configsTriangle;
+  TCoeff value;
 
-    value=0;
+  value = 0;
 
-    configsTriangle=row1ToTriangle[config1]+row2ToTriangle[config2]+row3ToTriangle[config3]+row4ToTriangle[config4];
-    value+=ConfigPMValue(pcmove, configsTriangle&0xFFFF, C4J, offsetJTriangle);
-    value+=ConfigPMValue(pcmove, configsTriangle>>16,    C4J, offsetJTriangle);
+  configsTriangle = row1ToTriangle[config1] + row2ToTriangle[config2] +
+                    row3ToTriangle[config3] + row4ToTriangle[config4];
+  value +=
+      ConfigPMValue(pcmove, configsTriangle & 0xFFFF, C4J, offsetJTriangle);
+  value += ConfigPMValue(pcmove, configsTriangle >> 16, C4J, offsetJTriangle);
 
-    return value;
+  return value;
 }
-
 
 // pos2 evaluators
 #if defined(__GNUC__) && defined(__x86_64__) && !defined(__MINGW32__)
 __attribute__((target("default")))
 #endif
-CValue CEvaluator::EvalMobs(const Pos2& pos2, u4 nMovesPlayer, u4 nMovesOpponent) const {
-    CBitBoard bb = pos2.GetBB();
-    TCoeff *const pcoeffs = this->pcoeffs[pos2.NEmpty()];
-// This function implements a linear pattern evaluator. 
-//
-// Most of the work is in extracting base-3 patterns such as rows, columns,
-// diagonals, and certain corner regions. These base-3 values index into the
-// pcoeffs array. The sum for the resulting pcoeffs values is the main
-// component of the static evaluation.
-//
-// The other three components of the static evaluation are:
-// * mobility (nMovesPlayer and nMovesOpponent are passed to this function)
-// * potential mobility (the potential mobility values are baked into the
-//   base-3 patterns, as the lower-order bits of the resulting value)
-// * parity
-// 
-// There are several strategies for extracting the patterns:
-// * For rows: shift, mask and conversion to base 3 via base2ToBase3Table
-//   table lookup - see  BB_EXTRACT_ROW_PATTERN macro
-// * For columns, diagonally flip the position and then use a strategy
-//   similar to the row one - see BB_EXTRACT_FLIPPED_ROW_PATTERN
-// * For most of the diagonals, the magic multiply trick (a.k.a. kindergarten
-//   bitboards or bit gather via multiplication) is used to gather the bits,
-//   then base2ToBase3Table converts to base 3.
-// * For some of the smaller diagonals, the bit gather operation can be
-//   combined directly with base 2-to-base 3 conversion, eliminating the need
-//   for a table lookup. The mechanism is described here:
-//   http://drpetric.blogspot.com/2014/03/bit-gathering-and-base-2-to-base-3.htm
-// * For corner regions, table lookups convert the row (or column) base 3
-//   patterns to their corner region formats.
-//
-// The layout of this function may seem "funky". The intent is to minimize the
-// number of overlapping live values, in order to reduce the number of
-// potential register spills onto the stack (amd64 a.k.a. x86_64 has only 15
-// GPRs). That is why we start with diagonals - we only need the diagonals for
-// their corresponding pattern values. The rows, on the other hand, are needed
-// for corner areas.
-// 
-    // Value has a lower 16 bit component and a higher one. The lower bits are used to
-    // unpack potmob values (potential mobility)
-    TCoeff value = 0;
+CValue
+CEvaluator::EvalMobs(const Pos2 &pos2, u4 nMovesPlayer,
+                     u4 nMovesOpponent) const {
+  CBitBoard bb = pos2.GetBB();
+  TCoeff *const pcoeffs = this->pcoeffs[pos2.NEmpty()];
+  // This function implements a linear pattern evaluator.
+  //
+  // Most of the work is in extracting base-3 patterns such as rows, columns,
+  // diagonals, and certain corner regions. These base-3 values index into the
+  // pcoeffs array. The sum for the resulting pcoeffs values is the main
+  // component of the static evaluation.
+  //
+  // The other three components of the static evaluation are:
+  // * mobility (nMovesPlayer and nMovesOpponent are passed to this function)
+  // * potential mobility (the potential mobility values are baked into the
+  //   base-3 patterns, as the lower-order bits of the resulting value)
+  // * parity
+  //
+  // There are several strategies for extracting the patterns:
+  // * For rows: shift, mask and conversion to base 3 via base2ToBase3Table
+  //   table lookup - see  BB_EXTRACT_ROW_PATTERN macro
+  // * For columns, diagonally flip the position and then use a strategy
+  //   similar to the row one - see BB_EXTRACT_FLIPPED_ROW_PATTERN
+  // * For most of the diagonals, the magic multiply trick (a.k.a. kindergarten
+  //   bitboards or bit gather via multiplication) is used to gather the bits,
+  //   then base2ToBase3Table converts to base 3.
+  // * For some of the smaller diagonals, the bit gather operation can be
+  //   combined directly with base 2-to-base 3 conversion, eliminating the need
+  //   for a table lookup. The mechanism is described here:
+  //   http://drpetric.blogspot.com/2014/03/bit-gathering-and-base-2-to-base-3.htm
+  // * For corner regions, table lookups convert the row (or column) base 3
+  //   patterns to their corner region formats.
+  //
+  // The layout of this function may seem "funky". The intent is to minimize the
+  // number of overlapping live values, in order to reduce the number of
+  // potential register spills onto the stack (amd64 a.k.a. x86_64 has only 15
+  // GPRs). That is why we start with diagonals - we only need the diagonals for
+  // their corresponding pattern values. The rows, on the other hand, are needed
+  // for corner areas.
+  //
+  // Value has a lower 16 bit component and a higher one. The lower bits are
+  // used to unpack potmob values (potential mobility)
+  TCoeff value = 0;
 
-    // mobility
-    value += (ConfigValue(pcoeffs, nMovesPlayer, M1J, offsetJMP) +
-              ConfigValue(pcoeffs, nMovesOpponent, M2J, offsetJMO) +
-    // parity
-              ConfigValue(pcoeffs, pos2.NEmpty()&1, PARJ, offsetJPAR)) << 16;
+  // mobility
+  value += (ConfigValue(pcoeffs, nMovesPlayer, M1J, offsetJMP) +
+            ConfigValue(pcoeffs, nMovesOpponent, M2J, offsetJMO) +
+            // parity
+            ConfigValue(pcoeffs, pos2.NEmpty() & 1, PARJ, offsetJPAR))
+           << 16;
 
-    uint64_t empty = bb.empty;
-    uint64_t mover = bb.mover;
+  uint64_t empty = bb.empty;
+  uint64_t mover = bb.mover;
 
-    // EXTRACT_BITS_U64 takes four parameters:
-    // base value
-    // start bit (constant)
-    // count (constant)
-    // step (constant)
+  // EXTRACT_BITS_U64 takes four parameters:
+  // base value
+  // start bit (constant)
+  // count (constant)
+  // step (constant)
 
-#define BB_EXTRACT_STEP_PATTERN(START, COUNT, STEP) \
-    base2ToBase3Table[EXTRACT_BITS_U64(empty, (START), (COUNT), (STEP))] + \
-    base2ToBase3Table[EXTRACT_BITS_U64(mover, (START), (COUNT), (STEP))] * 2
+#define BB_EXTRACT_STEP_PATTERN(START, COUNT, STEP)                            \
+  base2ToBase3Table[EXTRACT_BITS_U64(empty, (START), (COUNT), (STEP))] +       \
+      base2ToBase3Table[EXTRACT_BITS_U64(mover, (START), (COUNT), (STEP))] * 2
 
-    const TCoeff* const pD5 = pcoeffs+offsetJD5;
-    const TCoeff* const pD6 = pcoeffs+offsetJD6;
-    const TCoeff* const pD7 = pcoeffs+offsetJD7;
-    const TCoeff* const pD8 = pcoeffs+offsetJD8;
+  const TCoeff *const pD5 = pcoeffs + offsetJD5;
+  const TCoeff *const pD6 = pcoeffs + offsetJD6;
+  const TCoeff *const pD7 = pcoeffs + offsetJD7;
+  const TCoeff *const pD8 = pcoeffs + offsetJD8;
 
-    // Diagonals of type A run NWSE, with a bit step of 9.
-    // Type B diagonals run NESW, with a bit step of 7.
-    // Diag 8A and 8B
-    value += pD8[BB_EXTRACT_STEP_PATTERN(0, 8, 9)];
-    uint32_t Diag8B =
-        base2ToBase3Table[extract_second_diagonal(empty)] +
-        base2ToBase3Table[extract_second_diagonal(mover)] * 2;
-    value += pD8[Diag8B]; 
+  // Diagonals of type A run NWSE, with a bit step of 9.
+  // Type B diagonals run NESW, with a bit step of 7.
+  // Diag 8A and 8B
+  value += pD8[BB_EXTRACT_STEP_PATTERN(0, 8, 9)];
+  uint32_t Diag8B = base2ToBase3Table[extract_second_diagonal(empty)] +
+                    base2ToBase3Table[extract_second_diagonal(mover)] * 2;
+  value += pD8[Diag8B];
 
-    value += pD7[BB_EXTRACT_STEP_PATTERN(1, 7, 9)];
-    value += pD7[BB_EXTRACT_STEP_PATTERN(8, 7, 9)];
-    value += pD7[BB_EXTRACT_STEP_PATTERN(6, 7, 7)];
-    value += pD7[BB_EXTRACT_STEP_PATTERN(15, 7, 7)];
+  value += pD7[BB_EXTRACT_STEP_PATTERN(1, 7, 9)];
+  value += pD7[BB_EXTRACT_STEP_PATTERN(8, 7, 9)];
+  value += pD7[BB_EXTRACT_STEP_PATTERN(6, 7, 7)];
+  value += pD7[BB_EXTRACT_STEP_PATTERN(15, 7, 7)];
 
-    // Diag6 B1 and B2 
-    value += pD6[BB_EXTRACT_STEP_PATTERN(5, 6, 7)];
-    value += pD6[BB_EXTRACT_STEP_PATTERN(23, 6, 7)];
+  // Diag6 B1 and B2
+  value += pD6[BB_EXTRACT_STEP_PATTERN(5, 6, 7)];
+  value += pD6[BB_EXTRACT_STEP_PATTERN(23, 6, 7)];
 
-    // The 0x2030486ca2f300 multiplier will perform the bit gather +
-    // base 3 conversion for the 6-long diagonal starting on bit 2, with
-    // a step of 9 bits (a.k.a. Diag 6A1).
-    // Similar multipliers can be determined for diagonals 6A2, 5A1 and 5A2.
-    // However, it is cheaper to reduce 6A2, 5A1 and 5A2 to 6A1 via a
-    // shift, rather than load a different constant every single time.
-    // The compiler reuses the constants quite effectively.
+  // The 0x2030486ca2f300 multiplier will perform the bit gather +
+  // base 3 conversion for the 6-long diagonal starting on bit 2, with
+  // a step of 9 bits (a.k.a. Diag 6A1).
+  // Similar multipliers can be determined for diagonals 6A2, 5A1 and 5A2.
+  // However, it is cheaper to reduce 6A2, 5A1 and 5A2 to 6A1 via a
+  // shift, rather than load a different constant every single time.
+  // The compiler reuses the constants quite effectively.
 
-    uint64_t Diag6A1 =
-        (((empty & meta_repeated_bit<uint64_t, 2, 6, 9>::value) * 0x2030486ca2f300) >> 55) +
-        2 * (((mover & meta_repeated_bit<uint64_t, 2, 6, 9>::value) * 0x2030486ca2f300) >> 55);
-    value += pD6[Diag6A1];
-    uint64_t Diag6A2 =
-        ((((empty & meta_repeated_bit<uint64_t, 16, 6, 9>::value) >> 14) * 0x2030486ca2f300) >> 55) +
-        2 * ((((mover & meta_repeated_bit<uint64_t, 16, 6, 9>::value) >> 14) * 0x2030486ca2f300) >> 55);
-    value += pD6[Diag6A2];
+  uint64_t Diag6A1 =
+      (((empty & meta_repeated_bit<uint64_t, 2, 6, 9>::value) *
+        0x2030486ca2f300) >>
+       55) +
+      2 * (((mover & meta_repeated_bit<uint64_t, 2, 6, 9>::value) *
+            0x2030486ca2f300) >>
+           55);
+  value += pD6[Diag6A1];
+  uint64_t Diag6A2 =
+      ((((empty & meta_repeated_bit<uint64_t, 16, 6, 9>::value) >> 14) *
+        0x2030486ca2f300) >>
+       55) +
+      2 * ((((mover & meta_repeated_bit<uint64_t, 16, 6, 9>::value) >> 14) *
+            0x2030486ca2f300) >>
+           55);
+  value += pD6[Diag6A2];
 
-    uint64_t Diag5A1 =
-         ((((empty & meta_repeated_bit<uint64_t, 3, 5, 9>::value) >> 1) * 0x2030486ca2f300) >> 55) +
-         2 * ((((mover & meta_repeated_bit<uint64_t, 3, 5, 9>::value) >> 1) * 0x2030486ca2f300) >> 55);
-    value += pD5[Diag5A1];
-    uint64_t Diag5A2 =
-         ((((empty & meta_repeated_bit<uint64_t, 24, 5, 9>::value) >> 22) * 0x2030486ca2f300) >> 55) +
-         2 * ((((mover & meta_repeated_bit<uint64_t, 24, 5, 9>::value) >> 22) * 0x2030486ca2f300) >> 55);
-    value += pD5[Diag5A2];
+  uint64_t Diag5A1 =
+      ((((empty & meta_repeated_bit<uint64_t, 3, 5, 9>::value) >> 1) *
+        0x2030486ca2f300) >>
+       55) +
+      2 * ((((mover & meta_repeated_bit<uint64_t, 3, 5, 9>::value) >> 1) *
+            0x2030486ca2f300) >>
+           55);
+  value += pD5[Diag5A1];
+  uint64_t Diag5A2 =
+      ((((empty & meta_repeated_bit<uint64_t, 24, 5, 9>::value) >> 22) *
+        0x2030486ca2f300) >>
+       55) +
+      2 * ((((mover & meta_repeated_bit<uint64_t, 24, 5, 9>::value) >> 22) *
+            0x2030486ca2f300) >>
+           55);
+  value += pD5[Diag5A2];
 
-    // The 0x20c49ba2000000 multiplier performs bit gather + base 3 conversion
-    // for the 5-long diagonal starting on bit 4, with a step of 7 bits 5(a.k.a.
-    // Diag5B1). Similarly, we reduce 5B2 to 5B1 via a shift.
-    uint64_t Diag5B1 =  
-         ((((empty & meta_repeated_bit<uint64_t, 4, 5, 7>::value)) * 0x20c49ba2000000) >> 57) +
-         2 * ((((mover & meta_repeated_bit<uint64_t, 4, 5, 7>::value)) * 0x20c49ba2000000) >> 57);
-    value += pD5[Diag5B1];
-    uint64_t Diag5B2 = 
-         ((((empty & meta_repeated_bit<uint64_t, 31, 5, 7>::value) >> 27) * 0x20c49ba2000000) >> 57) +
-         2 * ((((mover & meta_repeated_bit<uint64_t, 31, 5, 7>::value) >> 27) * 0x20c49ba2000000) >> 57);
-    value += pD5[Diag5B2];
+  // The 0x20c49ba2000000 multiplier performs bit gather + base 3 conversion
+  // for the 5-long diagonal starting on bit 4, with a step of 7 bits 5(a.k.a.
+  // Diag5B1). Similarly, we reduce 5B2 to 5B1 via a shift.
+  uint64_t Diag5B1 =
+      ((((empty & meta_repeated_bit<uint64_t, 4, 5, 7>::value)) *
+        0x20c49ba2000000) >>
+       57) +
+      2 * ((((mover & meta_repeated_bit<uint64_t, 4, 5, 7>::value)) *
+            0x20c49ba2000000) >>
+           57);
+  value += pD5[Diag5B1];
+  uint64_t Diag5B2 =
+      ((((empty & meta_repeated_bit<uint64_t, 31, 5, 7>::value) >> 27) *
+        0x20c49ba2000000) >>
+       57) +
+      2 * ((((mover & meta_repeated_bit<uint64_t, 31, 5, 7>::value) >> 27) *
+            0x20c49ba2000000) >>
+           57);
+  value += pD5[Diag5B2];
 #undef BB_EXTRACT_STEP_PATTERN
 
-    const TCoeff* const pR1 = pcoeffs+offsetJR1;
-    const TCoeff* const pR2 = pcoeffs+offsetJR2;
-    const TCoeff* const pR3 = pcoeffs+offsetJR3;
-    const TCoeff* const pR4 = pcoeffs+offsetJR4;
+  const TCoeff *const pR1 = pcoeffs + offsetJR1;
+  const TCoeff *const pR2 = pcoeffs + offsetJR2;
+  const TCoeff *const pR3 = pcoeffs + offsetJR3;
+  const TCoeff *const pR4 = pcoeffs + offsetJR4;
 
-#define BB_EXTRACT_ROW_PATTERN(ROW) \
-    base2ToBase3Table[(empty >> (8 * (ROW))) & 0xff] + \
-    base2ToBase3Table[(mover >> (8 * (ROW))) & 0xff] * 2
+#define BB_EXTRACT_ROW_PATTERN(ROW)                                            \
+  base2ToBase3Table[(empty >> (8 * (ROW))) & 0xff] +                           \
+      base2ToBase3Table[(mover >> (8 * (ROW))) & 0xff] * 2
 
-    TConfig Row0 = BB_EXTRACT_ROW_PATTERN(0);
-    value += pR1[Row0];
-    TConfig Row1 = BB_EXTRACT_ROW_PATTERN(1);
-    value += pR2[Row1];
-    value += ValueEdgePatternsJ(pcoeffs, Row0, Row1) << 16;
-    TConfig Row2 = BB_EXTRACT_ROW_PATTERN(2);
-    value += pR3[Row2];
-    TConfig Row3 = BB_EXTRACT_ROW_PATTERN(3);
-    value += pR4[Row3];
-    value += ValueTrianglePatternsJ(pcoeffs, Row0, Row1, Row2, Row3);
+  TConfig Row0 = BB_EXTRACT_ROW_PATTERN(0);
+  value += pR1[Row0];
+  TConfig Row1 = BB_EXTRACT_ROW_PATTERN(1);
+  value += pR2[Row1];
+  value += ValueEdgePatternsJ(pcoeffs, Row0, Row1) << 16;
+  TConfig Row2 = BB_EXTRACT_ROW_PATTERN(2);
+  value += pR3[Row2];
+  TConfig Row3 = BB_EXTRACT_ROW_PATTERN(3);
+  value += pR4[Row3];
+  value += ValueTrianglePatternsJ(pcoeffs, Row0, Row1, Row2, Row3);
 
-    TConfig Row6 = BB_EXTRACT_ROW_PATTERN(6);
-    value += pR2[Row6];
-    TConfig Row7 = BB_EXTRACT_ROW_PATTERN(7);
-    value += ValueEdgePatternsJ(pcoeffs, Row7, Row6) << 16;
-    value += pR1[Row7];
-    TConfig Row4 = BB_EXTRACT_ROW_PATTERN(4);
-    value += pR4[Row4];
-    TConfig Row5 = BB_EXTRACT_ROW_PATTERN(5);
-    value += pR3[Row5];
-    value += ValueTrianglePatternsJ(pcoeffs, Row7, Row6, Row5, Row4);
+  TConfig Row6 = BB_EXTRACT_ROW_PATTERN(6);
+  value += pR2[Row6];
+  TConfig Row7 = BB_EXTRACT_ROW_PATTERN(7);
+  value += ValueEdgePatternsJ(pcoeffs, Row7, Row6) << 16;
+  value += pR1[Row7];
+  TConfig Row4 = BB_EXTRACT_ROW_PATTERN(4);
+  value += pR4[Row4];
+  TConfig Row5 = BB_EXTRACT_ROW_PATTERN(5);
+  value += pR3[Row5];
+  value += ValueTrianglePatternsJ(pcoeffs, Row7, Row6, Row5, Row4);
 #undef BB_EXTRACT_ROW_PATTERN
-    
-    uint64_t flippedMover = flipDiagonal(mover);
-    uint64_t flippedEmpty = flipDiagonal(empty);
 
-#define BB_EXTRACT_FLIPPED_ROW_PATTERN(ROW) \
-    base2ToBase3Table[(flippedEmpty >> (8 * (ROW))) & 0xff] + \
-    base2ToBase3Table[(flippedMover >> (8 * (ROW))) & 0xff] * 2
-    
-    TConfig Column0 = BB_EXTRACT_FLIPPED_ROW_PATTERN(0);
-    value += pR1[Column0];
-    TConfig Column1 = BB_EXTRACT_FLIPPED_ROW_PATTERN(1);
-    value += pR2[Column1];
-    value += ValueEdgePatternsJ(pcoeffs, Column0, Column1) << 16;
-    TConfig Column6 = BB_EXTRACT_FLIPPED_ROW_PATTERN(6);
-    value += pR2[Column6];
-    TConfig Column7 = BB_EXTRACT_FLIPPED_ROW_PATTERN(7);
-    value += pR1[Column7];
-    value += ValueEdgePatternsJ(pcoeffs, Column7, Column6) << 16;
-    value += pR3[BB_EXTRACT_FLIPPED_ROW_PATTERN(2)];
-    value += pR3[BB_EXTRACT_FLIPPED_ROW_PATTERN(5)];
-    value += pR4[BB_EXTRACT_FLIPPED_ROW_PATTERN(3)];
-    value += pR4[BB_EXTRACT_FLIPPED_ROW_PATTERN(4)];
+  uint64_t flippedMover = flipDiagonal(mover);
+  uint64_t flippedEmpty = flipDiagonal(empty);
+
+#define BB_EXTRACT_FLIPPED_ROW_PATTERN(ROW)                                    \
+  base2ToBase3Table[(flippedEmpty >> (8 * (ROW))) & 0xff] +                    \
+      base2ToBase3Table[(flippedMover >> (8 * (ROW))) & 0xff] * 2
+
+  TConfig Column0 = BB_EXTRACT_FLIPPED_ROW_PATTERN(0);
+  value += pR1[Column0];
+  TConfig Column1 = BB_EXTRACT_FLIPPED_ROW_PATTERN(1);
+  value += pR2[Column1];
+  value += ValueEdgePatternsJ(pcoeffs, Column0, Column1) << 16;
+  TConfig Column6 = BB_EXTRACT_FLIPPED_ROW_PATTERN(6);
+  value += pR2[Column6];
+  TConfig Column7 = BB_EXTRACT_FLIPPED_ROW_PATTERN(7);
+  value += pR1[Column7];
+  value += ValueEdgePatternsJ(pcoeffs, Column7, Column6) << 16;
+  value += pR3[BB_EXTRACT_FLIPPED_ROW_PATTERN(2)];
+  value += pR3[BB_EXTRACT_FLIPPED_ROW_PATTERN(5)];
+  value += pR4[BB_EXTRACT_FLIPPED_ROW_PATTERN(3)];
+  value += pR4[BB_EXTRACT_FLIPPED_ROW_PATTERN(4)];
 #undef BB_EXTRACT_FLIPPED_ROW_PATTERN
 
+  // Take apart packed information about pot mobilities
+  unsigned nPMO = (value >> 8) & 0xFF;
+  unsigned nPMP = value & 0xFF;
+  nPMO = (nPMO + potMobAdd) >> potMobShift;
+  nPMP = (nPMP + potMobAdd) >> potMobShift;
+  value >>= 16;
 
-    // Take apart packed information about pot mobilities
-    unsigned nPMO=(value>>8) & 0xFF;
-    unsigned nPMP=value&0xFF;
-    nPMO=(nPMO+potMobAdd)>>potMobShift;
-    nPMP=(nPMP+potMobAdd)>>potMobShift;
-    value>>=16;
+  // pot mobility
+  value += ConfigValue(pcoeffs, nPMP, PM1J, offsetJPMP);
+  value += ConfigValue(pcoeffs, nPMO, PM2J, offsetJPMO);
 
-    // pot mobility
-    value += ConfigValue(pcoeffs, nPMP, PM1J, offsetJPMP);
-    value += ConfigValue(pcoeffs, nPMO, PM2J, offsetJPMO);
-
-    return CValue(value);
+  return CValue(value);
 }
 
 #if defined(__GNUC__) && defined(__x86_64__) && !defined(__MINGW32__)
-__attribute__((target("bmi2")))
-CValue CEvaluator::EvalMobs(const Pos2& pos2, u4 nMovesPlayer, u4 nMovesOpponent) const {
-    CBitBoard bb = pos2.GetBB();
-    const TCoeff *const pcoeffs = this->pcoeffs[pos2.NEmpty()];
-    // This is a specialization of the Evaluator using the bmi2 pext instruction (_pext_u64)
+__attribute__((target("bmi2"))) CValue CEvaluator::EvalMobs(
+    const Pos2 &pos2, u4 nMovesPlayer, u4 nMovesOpponent) const {
+  CBitBoard bb = pos2.GetBB();
+  const TCoeff *const pcoeffs = this->pcoeffs[pos2.NEmpty()];
+  // This is a specialization of the Evaluator using the bmi2 pext instruction
+  // (_pext_u64)
 
-    // Value has a lower 16 bit component and a higher one. The lower bits are used to
-    // unpack potmob values (potential mobility)
-    TCoeff value = 0;
+  // Value has a lower 16 bit component and a higher one. The lower bits are
+  // used to unpack potmob values (potential mobility)
+  TCoeff value = 0;
 
-    // mobility
-    value += (ConfigValue(pcoeffs, nMovesPlayer, M1J, offsetJMP) +
-              ConfigValue(pcoeffs, nMovesOpponent, M2J, offsetJMO) +
-    // parity
-              ConfigValue(pcoeffs, pos2.NEmpty()&1, PARJ, offsetJPAR)) << 16;
+  // mobility
+  value += (ConfigValue(pcoeffs, nMovesPlayer, M1J, offsetJMP) +
+            ConfigValue(pcoeffs, nMovesOpponent, M2J, offsetJMO) +
+            // parity
+            ConfigValue(pcoeffs, pos2.NEmpty() & 1, PARJ, offsetJPAR))
+           << 16;
 
-    uint64_t empty = bb.empty;
-    uint64_t mover = bb.mover;
+  uint64_t empty = bb.empty;
+  uint64_t mover = bb.mover;
 
-    const TCoeff* const pR1 = pcoeffs+offsetJR1;
-    const TCoeff* const pR2 = pcoeffs+offsetJR2;
-    const TCoeff* const pR3 = pcoeffs+offsetJR3;
-    const TCoeff* const pR4 = pcoeffs+offsetJR4;
+  const TCoeff *const pR1 = pcoeffs + offsetJR1;
+  const TCoeff *const pR2 = pcoeffs + offsetJR2;
+  const TCoeff *const pR3 = pcoeffs + offsetJR3;
+  const TCoeff *const pR4 = pcoeffs + offsetJR4;
 
-#define BB_EXTRACT_ROW_PATTERN(ROW) \
-    base2ToBase3Table[(empty >> (8 * (ROW))) & 0xff] + \
-    base2ToBase3Table[(mover >> (8 * (ROW))) & 0xff] * 2
+#define BB_EXTRACT_ROW_PATTERN(ROW)                                            \
+  base2ToBase3Table[(empty >> (8 * (ROW))) & 0xff] +                           \
+      base2ToBase3Table[(mover >> (8 * (ROW))) & 0xff] * 2
 
-    TConfig Row0 = BB_EXTRACT_ROW_PATTERN(0);
-    value += pR1[Row0];
-    TConfig Row1 = BB_EXTRACT_ROW_PATTERN(1);
-    value += pR2[Row1];
-    value += ValueEdgePatternsJ(pcoeffs, Row0, Row1) << 16;
-    TConfig Row2 = BB_EXTRACT_ROW_PATTERN(2);
-    value += pR3[Row2];
-    TConfig Row3 = BB_EXTRACT_ROW_PATTERN(3);
-    value += pR4[Row3];
-    value += ValueTrianglePatternsJ(pcoeffs, Row0, Row1, Row2, Row3);
+  TConfig Row0 = BB_EXTRACT_ROW_PATTERN(0);
+  value += pR1[Row0];
+  TConfig Row1 = BB_EXTRACT_ROW_PATTERN(1);
+  value += pR2[Row1];
+  value += ValueEdgePatternsJ(pcoeffs, Row0, Row1) << 16;
+  TConfig Row2 = BB_EXTRACT_ROW_PATTERN(2);
+  value += pR3[Row2];
+  TConfig Row3 = BB_EXTRACT_ROW_PATTERN(3);
+  value += pR4[Row3];
+  value += ValueTrianglePatternsJ(pcoeffs, Row0, Row1, Row2, Row3);
 
-    TConfig Row6 = BB_EXTRACT_ROW_PATTERN(6);
-    value += pR2[Row6];
-    TConfig Row7 = BB_EXTRACT_ROW_PATTERN(7);
-    value += pR1[Row7];
-    value += ValueEdgePatternsJ(pcoeffs, Row7, Row6) << 16;
-    TConfig Row4 = BB_EXTRACT_ROW_PATTERN(4);
-    value += pR4[Row4];
-    TConfig Row5 = BB_EXTRACT_ROW_PATTERN(5);
-    value += pR3[Row5];
-    value += ValueTrianglePatternsJ(pcoeffs, Row7, Row6, Row5, Row4);
+  TConfig Row6 = BB_EXTRACT_ROW_PATTERN(6);
+  value += pR2[Row6];
+  TConfig Row7 = BB_EXTRACT_ROW_PATTERN(7);
+  value += pR1[Row7];
+  value += ValueEdgePatternsJ(pcoeffs, Row7, Row6) << 16;
+  TConfig Row4 = BB_EXTRACT_ROW_PATTERN(4);
+  value += pR4[Row4];
+  TConfig Row5 = BB_EXTRACT_ROW_PATTERN(5);
+  value += pR3[Row5];
+  value += ValueTrianglePatternsJ(pcoeffs, Row7, Row6, Row5, Row4);
 #undef BB_EXTRACT_ROW_PATTERN
 
-#define BB_EXTRACT_STEP_PATTERN(START, COUNT, STEP) \
-        (base2ToBase3Table[_pext_u64(empty, meta_repeated_bit<uint64_t, (START), (COUNT), (STEP)>::value)] + \
-         2 * base2ToBase3Table[_pext_u64(mover, meta_repeated_bit<uint64_t, (START), (COUNT), (STEP)>::value)])
+#define BB_EXTRACT_STEP_PATTERN(START, COUNT, STEP)                            \
+  (base2ToBase3Table[_pext_u64(                                                \
+       empty, meta_repeated_bit<uint64_t, (START), (COUNT), (STEP)>::value)] + \
+   2 * base2ToBase3Table[_pext_u64(                                            \
+           mover,                                                              \
+           meta_repeated_bit<uint64_t, (START), (COUNT), (STEP)>::value)])
 
-    value += pcoeffs[offsetJD8 + BB_EXTRACT_STEP_PATTERN(0, 8, 9)];
-    value += pcoeffs[offsetJD7 + BB_EXTRACT_STEP_PATTERN(1, 7, 9)];
-    value += pcoeffs[offsetJD7 + BB_EXTRACT_STEP_PATTERN(8, 7, 9)];
-    value += pcoeffs[offsetJD6 + BB_EXTRACT_STEP_PATTERN(2, 6, 9)];
-    value += pcoeffs[offsetJD6 + BB_EXTRACT_STEP_PATTERN(16, 6, 9)];
-    value += pcoeffs[offsetJD5 + BB_EXTRACT_STEP_PATTERN(3, 5, 9)];
-    value += pcoeffs[offsetJD5 + BB_EXTRACT_STEP_PATTERN(24, 5, 9)];
-    value += pcoeffs[offsetJD8 + BB_EXTRACT_STEP_PATTERN(7, 8, 7)];
-    value += pcoeffs[offsetJD7 + BB_EXTRACT_STEP_PATTERN(6, 7, 7)];
-    value += pcoeffs[offsetJD7 + BB_EXTRACT_STEP_PATTERN(15, 7, 7)];
-    value += pcoeffs[offsetJD6 + BB_EXTRACT_STEP_PATTERN(5, 6, 7)];
-    value += pcoeffs[offsetJD6 + BB_EXTRACT_STEP_PATTERN(23, 6, 7)];
-    value += pcoeffs[offsetJD5 + BB_EXTRACT_STEP_PATTERN(4, 5, 7)];
-    value += pcoeffs[offsetJD5 + BB_EXTRACT_STEP_PATTERN(31, 5, 7)];
+  value += pcoeffs[offsetJD8 + BB_EXTRACT_STEP_PATTERN(0, 8, 9)];
+  value += pcoeffs[offsetJD7 + BB_EXTRACT_STEP_PATTERN(1, 7, 9)];
+  value += pcoeffs[offsetJD7 + BB_EXTRACT_STEP_PATTERN(8, 7, 9)];
+  value += pcoeffs[offsetJD6 + BB_EXTRACT_STEP_PATTERN(2, 6, 9)];
+  value += pcoeffs[offsetJD6 + BB_EXTRACT_STEP_PATTERN(16, 6, 9)];
+  value += pcoeffs[offsetJD5 + BB_EXTRACT_STEP_PATTERN(3, 5, 9)];
+  value += pcoeffs[offsetJD5 + BB_EXTRACT_STEP_PATTERN(24, 5, 9)];
+  value += pcoeffs[offsetJD8 + BB_EXTRACT_STEP_PATTERN(7, 8, 7)];
+  value += pcoeffs[offsetJD7 + BB_EXTRACT_STEP_PATTERN(6, 7, 7)];
+  value += pcoeffs[offsetJD7 + BB_EXTRACT_STEP_PATTERN(15, 7, 7)];
+  value += pcoeffs[offsetJD6 + BB_EXTRACT_STEP_PATTERN(5, 6, 7)];
+  value += pcoeffs[offsetJD6 + BB_EXTRACT_STEP_PATTERN(23, 6, 7)];
+  value += pcoeffs[offsetJD5 + BB_EXTRACT_STEP_PATTERN(4, 5, 7)];
+  value += pcoeffs[offsetJD5 + BB_EXTRACT_STEP_PATTERN(31, 5, 7)];
 #undef BB_EXTRACT_STEP_PATTERN
 
-    
-#define BB_EXTRACT_FLIPPED_ROW_PATTERN(ROW) \
-        (base2ToBase3Table[_pext_u64(empty, meta_repeated_bit<uint64_t, (ROW), 8, 8>::value)] +  \
-         2 * base2ToBase3Table[_pext_u64(mover, meta_repeated_bit<uint64_t, (ROW), 8, 8>::value)])
+#define BB_EXTRACT_FLIPPED_ROW_PATTERN(ROW)                                    \
+  (base2ToBase3Table[_pext_u64(                                                \
+       empty, meta_repeated_bit<uint64_t, (ROW), 8, 8>::value)] +              \
+   2 * base2ToBase3Table[_pext_u64(                                            \
+           mover, meta_repeated_bit<uint64_t, (ROW), 8, 8>::value)])
 
-    TConfig Column0 = BB_EXTRACT_FLIPPED_ROW_PATTERN(0);
-    value += pR1[Column0];
-    TConfig Column1 = BB_EXTRACT_FLIPPED_ROW_PATTERN(1);
-    value += pR2[Column1];
-    value += ValueEdgePatternsJ(pcoeffs, Column0, Column1) << 16;
-    TConfig Column6 = BB_EXTRACT_FLIPPED_ROW_PATTERN(6);
-    value += pR2[Column6];
-    TConfig Column7 = BB_EXTRACT_FLIPPED_ROW_PATTERN(7);
-    value += pR1[Column7];
-    value += ValueEdgePatternsJ(pcoeffs, Column7, Column6) << 16;
-    value += pR3[BB_EXTRACT_FLIPPED_ROW_PATTERN(2)];
-    value += pR3[BB_EXTRACT_FLIPPED_ROW_PATTERN(5)];
-    value += pR4[BB_EXTRACT_FLIPPED_ROW_PATTERN(3)];
-    value += pR4[BB_EXTRACT_FLIPPED_ROW_PATTERN(4)];
+  TConfig Column0 = BB_EXTRACT_FLIPPED_ROW_PATTERN(0);
+  value += pR1[Column0];
+  TConfig Column1 = BB_EXTRACT_FLIPPED_ROW_PATTERN(1);
+  value += pR2[Column1];
+  value += ValueEdgePatternsJ(pcoeffs, Column0, Column1) << 16;
+  TConfig Column6 = BB_EXTRACT_FLIPPED_ROW_PATTERN(6);
+  value += pR2[Column6];
+  TConfig Column7 = BB_EXTRACT_FLIPPED_ROW_PATTERN(7);
+  value += pR1[Column7];
+  value += ValueEdgePatternsJ(pcoeffs, Column7, Column6) << 16;
+  value += pR3[BB_EXTRACT_FLIPPED_ROW_PATTERN(2)];
+  value += pR3[BB_EXTRACT_FLIPPED_ROW_PATTERN(5)];
+  value += pR4[BB_EXTRACT_FLIPPED_ROW_PATTERN(3)];
+  value += pR4[BB_EXTRACT_FLIPPED_ROW_PATTERN(4)];
 #undef BB_EXTRACT_FLIPPED_ROW_PATTERN
 
+  // Take apart packed information about pot mobilities
+  unsigned nPMO = (value >> 8) & 0xFF;
+  unsigned nPMP = value & 0xFF;
+  nPMO = (nPMO + potMobAdd) >> potMobShift;
+  nPMP = (nPMP + potMobAdd) >> potMobShift;
+  value >>= 16;
 
-    // Take apart packed information about pot mobilities
-    unsigned nPMO=(value>>8) & 0xFF;
-    unsigned nPMP=value&0xFF;
-    nPMO=(nPMO+potMobAdd)>>potMobShift;
-    nPMP=(nPMP+potMobAdd)>>potMobShift;
-    value>>=16;
+  // pot mobility
+  value += ConfigValue(pcoeffs, nPMP, PM1J, offsetJPMP);
+  value += ConfigValue(pcoeffs, nPMO, PM2J, offsetJPMO);
 
-    // pot mobility
-    value += ConfigValue(pcoeffs, nPMP, PM1J, offsetJPMP);
-    value += ConfigValue(pcoeffs, nPMO, PM2J, offsetJPMO);
-
-    return CValue(value);
+  return CValue(value);
 }
 #endif

--- a/src/bookplay.cpp
+++ b/src/bookplay.cpp
@@ -6,69 +6,74 @@
 #include <sys/mman.h>
 
 #include <cstdlib>
-#include <fstream>
+
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 
-#include "core/CalcParams.h"
+#include "Evaluator.h"
+#include "PlayerComputer.h"
+#include "SmartBook.h"
 #include "core/Book.h"
 #include "core/Cache.h"
+#include "core/CalcParams.h"
 #include "core/MPCStats.h"
-#include "game/Player.h"
 #include "game/Game.h"
+#include "game/Player.h"
 #include "n64/flips.h"
 #include "n64/utils.h"
 #include "options.h"
 #include "pattern/FastFlip.h"
 #include "pattern/Patterns.h"
-#include "Evaluator.h"
-#include "PlayerComputer.h"
-#include "SmartBook.h"
 
 using namespace std;
 
 static CCache big_cache(16777216); // 512 MiB
 
-class CPlayerWithCache:  public CPlayerComputer {
+class CPlayerWithCache : public CPlayerComputer {
 public:
-  CPlayerWithCache(const CComputerDefaults& acd) {
-    cd=acd;
-    pcp=CCalcParams::NewFromString(cd.sCalcParams);
+  CPlayerWithCache(const CComputerDefaults &acd) {
+    cd = acd;
+    pcp = CCalcParams::NewFromString(cd.sCalcParams);
+#ifdef __linux__
     madvise(big_cache.buckets, sizeof(CCacheData) * big_cache.nBuckets,
-        MADV_HUGEPAGE);
+            MADV_HUGEPAGE);
+#endif
 
-    caches[0]=caches[1]=NULL;
-    fHasCachedPos[0]=fHasCachedPos[1]=false;
+    caches[0] = caches[1] = NULL;
+    fHasCachedPos[0] = fHasCachedPos[1] = false;
     std::cout << "status Loading book" << std::endl;
-    book=(cd.booklevel!=CComputerDefaults::kNoBook) ? CSmartBook::FindBook(cd.cEval, cd.cCoeffSet, pcp) : NULL;
-    eval=CEvaluator::FindEvaluator(cd.cEval, cd.cCoeffSet);
-    mpcs=CMPCStats::GetMPCStats(cd.cEval, cd.cCoeffSet, std::max(cd.iPruneMidgame, cd.iPruneEndgame));
-    fAnalyzingDeferred=false;
+    book = (cd.booklevel != CComputerDefaults::kNoBook)
+               ? CSmartBook::FindBook(cd.cEval, cd.cCoeffSet, pcp)
+               : NULL;
+    eval = CEvaluator::FindEvaluator(cd.cEval, cd.cCoeffSet);
+    mpcs = CMPCStats::GetMPCStats(cd.cEval, cd.cCoeffSet,
+                                  std::max(cd.iPruneMidgame, cd.iPruneEndgame));
+    fAnalyzingDeferred = false;
 
     // get saved-game file name
     std::ostringstream os;
-    os << fnBaseDir << "results/" << cd.cEval << cd.cCoeffSet << '_' << *pcp << ".ggf";
-    m_fnSaveGame=os.str();
-    
-    toot=false;
-    
+    os << fnBaseDir << "results/" << cd.cEval << cd.cCoeffSet << '_' << *pcp
+       << ".ggf";
+    m_fnSaveGame = os.str();
+
+    toot = false;
+
     // calculate computer's name
     std::ostringstream osName;
     pcp->Name(osName);
-    m_sName=osName.str();
+    m_sName = osName.str();
 
-    if (!mpcs) cd.iPruneMidgame=cd.iPruneEndgame=0;
-
+    if (!mpcs)
+      cd.iPruneMidgame = cd.iPruneEndgame = 0;
 
     std::cout << "status Negamaxing book" << std::endl;
-    SetupBook(cd.booklevel==CComputerDefaults::kNegamaxBook);
+    SetupBook(cd.booklevel == CComputerDefaults::kNegamaxBook);
     std::cout << "status" << std::endl;
   }
+
 protected:
-  CCache* GetCache(int iCache) override {
-    return &big_cache;
-  }
+  CCache *GetCache(int iCache) override { return &big_cache; }
 };
 
 void Init() {
@@ -87,54 +92,54 @@ void Init() {
 }
 
 // To satisfy linker in debug mode
-bool HasInput() {
-    return false;
-}
+bool HasInput() { return false; }
 
 int main(int argc, char **argv) {
-    cout << "Ntest version as of " << __DATE__ << "\n";
-    cout << "Copyright 1999-2014 Chris Welty and Vlad Petric\nAll Rights Reserved\n\n";
-    if (argc != 2) {
-      cerr << "Usage: " << argv[0] << " <initial file>"  << std::endl;
-    }
-    try {
-      mlockall(MCL_CURRENT | MCL_FUTURE);
-      cout << "Done locking pages" << std::endl;
-      for (unsigned depth: {26}) {
-        dGHz = 2.8;
-        maxCacheMem = 2ULL << 30; //2GiB 
-        Init();
-        CComputerDefaults cd1;
-        char buff[5];
-        snprintf(buff, 5, "s%d", depth);
-        cd1.sCalcParams = buff;
-        cd1.cEval = 'J';
-        cd1.cCoeffSet = 'A';
-        cd1.vContempts[0] = 0;
-        cd1.vContempts[1] = 0;
-        cd1.iPruneEndgame = 5;
-        cd1.iPruneMidgame = 4;
-        cd1.nRandShifts[0] = 2;
-        cd1.nRandShifts[1] = 2;
-        cd1.iEdmund = 1;
-        cd1.fsPrint = 0;
-        cd1.fsPrintOpponent = 0;
-        cd1.booklevel = CComputerDefaults::kBook;
+  cout << "Ntest version as of " << __DATE__ << "\n";
+  cout << "Copyright 1999-2014 Chris Welty and Vlad Petric\nAll Rights "
+          "Reserved\n\n";
+  if (argc != 2) {
+    cerr << "Usage: " << argv[0] << " <initial file>" << std::endl;
+  }
+  try {
+    mlockall(MCL_CURRENT | MCL_FUTURE);
+    cout << "Done locking pages" << std::endl;
+    for (unsigned depth : {26}) {
+      dGHz = 2.8;
+      maxCacheMem = 2ULL << 30; // 2GiB
+      Init();
+      CComputerDefaults cd1;
+      char buff[5];
+      snprintf(buff, 5, "s%d", depth);
+      cd1.sCalcParams = buff;
+      cd1.cEval = 'J';
+      cd1.cCoeffSet = 'A';
+      cd1.vContempts[0] = 0;
+      cd1.vContempts[1] = 0;
+      cd1.iPruneEndgame = 5;
+      cd1.iPruneMidgame = 4;
+      cd1.nRandShifts[0] = 2;
+      cd1.nRandShifts[1] = 2;
+      cd1.iEdmund = 1;
+      cd1.fsPrint = 0;
+      cd1.fsPrintOpponent = 0;
+      cd1.booklevel = CComputerDefaults::kBook;
 
-        fPrintExtensionInfo = false;
-        fPrintBoard = false;
-        fPrintAbort = false;
-        extern bool fPrintCorrections;
-        fPrintCorrections = false;
-        
-        CPlayer* p0 = new CPlayerWithCache(cd1);
-        for (unsigned i = 0; i < 33333; ++i) {
-            CGame(p0, p0, 15 * 60, argv[1]).Play();
-            cout << "\n\n\n Done with depth " << depth << " Game " << i << "\n\n" << endl;
-        }
-        delete p0;
+      fPrintExtensionInfo = false;
+      fPrintBoard = false;
+      fPrintAbort = false;
+      extern bool fPrintCorrections;
+      fPrintCorrections = false;
+
+      CPlayer *p0 = new CPlayerWithCache(cd1);
+      for (unsigned i = 0; i < 33333; ++i) {
+        CGame(p0, p0, 15 * 60, argv[1]).Play();
+        cout << "\n\n\n Done with depth " << depth << " Game " << i << "\n\n"
+             << endl;
+      }
+      delete p0;
     }
-  } catch(std::string exception) {
+  } catch (std::string exception) {
     cout << exception << "\n";
     return -1;
   }


### PR DESCRIPTION
- Update CMake minimum version from 2.8.5 to 3.5 for modern CMake compatibility
- Add platform-specific conditional for MADV_HUGEPAGE (Linux-only) in bookplay.cpp
- Improve error messages in Evaluator.cpp for coefficient file reading
- Fix resource file setup in CMakeLists.txt using file(COPY) instead of broken symlinks
- Remove unused fstream header from bookplay.cpp

All tests now pass on macOS.