### PR TITLE
Fix macOS build and check tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.5)
 
 project(ntest)
 
@@ -53,6 +53,11 @@ target_link_libraries(allpos mainlib core game patterns odk n64)
 add_test(ntest_basic ntest o)
 
 if(${UNIX})
-    EXEC_PROGRAM(ln ARGS -sf "../src/resource/*"
-                 "${CMAKE_BINARY_DIR}")
+    # Copy resource files to build directory for non-Windows platforms
+    file(COPY "${CMAKE_SOURCE_DIR}/resource/solver12.txt" DESTINATION "${CMAKE_BINARY_DIR}/resource")
+    file(COPY "${CMAKE_SOURCE_DIR}/resource/resource/" DESTINATION "${CMAKE_BINARY_DIR}/resource")
+    file(COPY "${CMAKE_SOURCE_DIR}/TestGames.ggf" DESTINATION "${CMAKE_BINARY_DIR}")
+    file(COPY "${CMAKE_SOURCE_DIR}/parameters.txt" DESTINATION "${CMAKE_BINARY_DIR}")
+    file(COPY "${CMAKE_SOURCE_DIR}/coefficients/" DESTINATION "${CMAKE_BINARY_DIR}/coefficients")
+    file(COPY "${CMAKE_SOURCE_DIR}/../resource/coefficients/" DESTINATION "${CMAKE_BINARY_DIR}/coefficients")
 endif()

--- a/src/Evaluator.cpp
+++ b/src/Evaluator.cpp
@@ -159,12 +159,17 @@ CEvaluator::CEvaluator(const std::string& fnBase, int nFiles) {
 
         // read in version and parameter info
         u4 fParams;
-        assert(fread(&iVersion, sizeof(iVersion), 1, fp) == 1);
-        assert(fread(&fParams, sizeof(fParams), 1, fp) == 1);
+        if (fread(&iVersion, sizeof(iVersion), 1, fp) != 1 ||
+            fread(&fParams, sizeof(fParams), 1, fp) != 1) {
+            std::cerr << "Evaluator: failed to read header from " << fn << std::endl;
+            throw std::string("error reading from coefficients file ")+fnBase;
+        }
         if (iVersion==1 && fParams==14) {
             ConvertFile(fp, fn, iVersion, fParams);
         }
         if (iVersion!=1 || (fParams!=100)) {
+            std::cerr << "Evaluator: bad coeff header in " << fn
+                      << " iVersion=" << iVersion << " fParams=" << fParams << std::endl;
             throw std::string("error reading from coefficients file ")+fnBase;
         }
 

--- a/src/bookplay.cpp
+++ b/src/bookplay.cpp
@@ -35,8 +35,10 @@ public:
   CPlayerWithCache(const CComputerDefaults& acd) {
     cd=acd;
     pcp=CCalcParams::NewFromString(cd.sCalcParams);
+#ifdef MADV_HUGEPAGE
     madvise(big_cache.buckets, sizeof(CCacheData) * big_cache.nBuckets,
         MADV_HUGEPAGE);
+#endif
 
     caches[0]=caches[1]=NULL;
     fHasCachedPos[0]=fHasCachedPos[1]=false;


### PR DESCRIPTION
- Raise CMake min to 3.5 and copy resources/coefficients into build/ using file(COPY ...) instead of symlinks.
- Guard the Linux-only MADV_HUGEPAGE call with #ifdef MADV_HUGEPAGE so it compiles on macOS.
- Fix the coefficient load issue in src/Evaluator.cpp: replaced asserts with explicit fread checks and diagnostic logging. This ensures the header is read even when asserts are compiled out.
- Also verified the tests are passing:

build % ctest --output-on-failure
Test project /Users/fdimeglio/src/Antigravity/ntest-petric/build
    Start 1: ntest_basic
1/3 Test #1: ntest_basic ......................   Passed    1.02 sec
    Start 2: bitExtract
2/3 Test #2: bitExtract .......................   Passed    0.00 sec
    Start 3: randomTest
3/3 Test #3: randomTest .......................   Passed    6.62 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   7.65 sec